### PR TITLE
Use email as recipient if not present

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The unique identification key of a notification template to be sent. If the noti
 
 ### recipient (optional)
 
-The unique identification key attached to a recipient and their profile. If empty, the code will auto-generate a unique key.
+The unique identification key attached to a recipient and their profile. The value should be a string, all other values will be converted to a string. If empty, the code will either use the email provided in the to or auto-generate a unique key.
 
 ### profile (optional)
 

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,4 @@ RSpec::Core::RakeTask.new(:spec)
 
 require "standard/rake"
 
-RuboCop::RakeTask.new
-
 task default: %i[spec standard]

--- a/lib/courier_rails/delivery_method.rb
+++ b/lib/courier_rails/delivery_method.rb
@@ -44,7 +44,7 @@ module CourierRails
 
     def prepare_recipient_from(mail, courier_data)
       @payload["recipient"] = if courier_data.has_key?(:recipient)
-        courier_data[:recipient]
+        courier_data[:recipient].to_s
       elsif !mail.to.nil?
         mail.to.first
       else

--- a/lib/courier_rails/delivery_method.rb
+++ b/lib/courier_rails/delivery_method.rb
@@ -42,9 +42,11 @@ module CourierRails
       end
     end
 
-    def prepare_recipient_from(_mail, courier_data)
+    def prepare_recipient_from(mail, courier_data)
       @payload["recipient"] = if courier_data.has_key?(:recipient)
         courier_data[:recipient]
+      elsif !mail.to.nil?
+        mail.to.first
       else
         SecureRandom.uuid
       end

--- a/spec/delivery_spec.rb
+++ b/spec/delivery_spec.rb
@@ -30,7 +30,15 @@ describe CourierRails::DeliveryMethod do
       expect(@delivery_method.payload["recipient"]).to eq("TEST_RECIPIENT")
     end
 
-    it "generates a recipient if not provided" do
+    it "uses email from to if not provided" do
+      test_email = Mailer.test_email to: "to@example.com", courier_data: {event: "TEST_EVENT"}
+
+      @delivery_method.deliver!(test_email)
+
+      expect(@delivery_method.payload["recipient"]).to eq("to@example.com")
+    end
+
+    it "generates a recipient if not provided and no to" do
       test_email = Mailer.test_email courier_data: {event: "TEST_EVENT"}
 
       @delivery_method.deliver!(test_email)

--- a/spec/delivery_spec.rb
+++ b/spec/delivery_spec.rb
@@ -30,6 +30,14 @@ describe CourierRails::DeliveryMethod do
       expect(@delivery_method.payload["recipient"]).to eq("TEST_RECIPIENT")
     end
 
+    it "converts provided recipient to a string" do
+      test_email = Mailer.test_email courier_data: {event: "TEST_EVENT", recipient: 12345}
+
+      @delivery_method.deliver!(test_email)
+
+      expect(@delivery_method.payload["recipient"]).to eq("12345")
+    end
+
     it "uses email from to if not provided" do
       test_email = Mailer.test_email to: "to@example.com", courier_data: {event: "TEST_EVENT"}
 


### PR DESCRIPTION
## Description of the change

If a recipient is not given, use the email from the to if available, else generate a UUID

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [x] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
